### PR TITLE
can_match now uses highest bid for selling

### DIFF
--- a/Orderbook/orderbook/src/lib.rs
+++ b/Orderbook/orderbook/src/lib.rs
@@ -1245,27 +1245,44 @@ mod test {
 
     #[test]
     fn test_orderbook_can_match() -> Result<(), Box<dyn std::error::Error>> {
-        //bid -> highest price buyer willing to pay
-        let mut bids: BTreeMap<Price, OrderIds> = BTreeMap::new();
-        //ask -> lowest price seller willing to accept
-        let mut asks: BTreeMap<Price, OrderIds> = BTreeMap::new();
+        let mut obj = Orderbook::new();
 
-        bids.insert(90, vec![0, 1, 2]);
-        bids.insert(100, vec![0, 1, 2]);
+        //bid = buy & ask = sell
 
-        asks.insert(100, vec![0, 1, 2]);
-        asks.insert(95, vec![0, 1, 2]);
+        //ask order with price 100
+        obj.add_order(Order::new(
+            0,
+            OrderType::GoodTillCancel,
+            2,
+            Side::Sell,
+            100,
+            1,
+        )?);
 
-        let price: Price = 95;
-        //-----Fix: Use the last bid (highest price) -------
-        //sold if highest price willing to buy >= lowest price willing to sell
-        let mut sold = bids.last_key_value().is_some_and(|(bid, _)| price <= *bid);
-        assert_eq!(sold, true);
+        obj.add_order(Order::new(
+            0,
+            OrderType::GoodTillCancel,
+            2,
+            Side::Buy,
+            80,
+            1,
+        )?);
 
-        //-----Replicate Original Bug -------
-        // sold = bids.first_key_value().is_some_and(|(bid, _)| price <= *bid);
-        // assert_eq!(sold, true);
+        //this bid order with price 105 should match the ask
+        obj.add_order(Order::new(
+            0,
+            OrderType::GoodTillCancel,
+            2,
+            Side::Buy,
+            105,
+            1,
+        )?);
 
+        if let Some(lowest_bid) = obj.bids.first_key_value() {
+            let (val, _) = lowest_bid;
+
+            assert_eq!(*val, 80);
+        };
         Ok(())
     }
 

--- a/Orderbook/orderbook/src/lib.rs
+++ b/Orderbook/orderbook/src/lib.rs
@@ -760,7 +760,7 @@ impl Orderbook {
                 .is_some_and(|(ask, _)| price >= *ask),
             Side::Sell => self
                 .bids
-                .first_key_value()
+                .last_key_value()
                 .is_some_and(|(bid, _)| price <= *bid),
         }
     }
@@ -1240,6 +1240,32 @@ mod test {
         )?);
 
         assert_eq!(ob1.size(), ob2.size());
+        Ok(())
+    }
+
+    #[test]
+    fn test_orderbook_can_match() -> Result<(), Box<dyn std::error::Error>> {
+        //bid -> highest price buyer willing to pay
+        let mut bids: BTreeMap<Price, OrderIds> = BTreeMap::new();
+        //ask -> lowest price seller willing to accept
+        let mut asks: BTreeMap<Price, OrderIds> = BTreeMap::new();
+
+        bids.insert(90, vec![0, 1, 2]);
+        bids.insert(100, vec![0, 1, 2]);
+
+        asks.insert(100, vec![0, 1, 2]);
+        asks.insert(95, vec![0, 1, 2]);
+
+        let price: Price = 95;
+        //-----Fix: Use the last bid (highest price) -------
+        //sold if highest price willing to buy >= lowest price willing to sell
+        let mut sold = bids.last_key_value().is_some_and(|(bid, _)| price <= *bid);
+        assert_eq!(sold, true);
+
+        //-----Replicate Original Bug -------
+        // sold = bids.first_key_value().is_some_and(|(bid, _)| price <= *bid);
+        // assert_eq!(sold, true);
+
         Ok(())
     }
 


### PR DESCRIPTION
added a test with both the replication and the fix. Can_match now uses the highest bid available so it can correctly determine whether it passes given the bid and the price.